### PR TITLE
added memory allocation to fastqc of 4Gb

### DIFF
--- a/src/npr/rules/3_qc.smk
+++ b/src/npr/rules/3_qc.smk
@@ -33,7 +33,7 @@ rule qc_fastqc:
     log:
         "log/fastqc/project-{project}_id-{sample_id}_name-{sample_name}.log"
     shell:'''
-    fastqc -t {threads} -o {params.odir} --dir {params.odir} --quiet {input}
+    fastqc --memory=4096 -t {threads} -o {params.odir} --dir {params.odir} --quiet {input}
     '''
 
 rule qc_reformat: 


### PR DESCRIPTION
Fastqc errors out because it runs out of memory. Added a 4Gb memory allocation. Change if more is needed.