### PR TITLE
add project ID to e-mail body

### DIFF
--- a/src/npr/communication.py
+++ b/src/npr/communication.py
@@ -160,6 +160,7 @@ def query_parkour(config, flowcell, msg):
             info_dict["protocol"] = protocol
             msg += "nucleic acid  type = {}\n".format(protocol)
             msg += "organism = {}\n".format(organism)
+            msg += "project id = {}\n".format(config["data"]["Sample_Project"])
             return (info_dict, msg)
     info_dict = {}
     msg += "Parkour query failed for {}.\n".format(fc)


### PR DESCRIPTION
It would appear at the bottom, to help track failed queries (until we add file.path as a field in the parkour DB, soon 🤞🏽 ; then we would have the flowcell path to cross-reference)