### PR TITLE
Manke

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -1,91 +1,110 @@
 options:
   sleep_time: 1 #in hour
 
-snakemake: 
+# static snakemake params that will passed
+snakemake:                                                                                                
   conda_prefix: /path/to/conda/prefix
-  cores: 24
+  cores: 4
+  dryrun: False
+  printdag: False
+  max_jobs_per_second: 1
+  printshellcmds: true
+  use_conda: true
+  verbose: true
+  rerun_triggers: ['mtime']
+  debug: False
+
+sambahost:
+  user: samba_user
+  host: samba_host
+  pkey: path/to/private_key
 
 paths:
-  offloadDir: /path/to/ont/files
-  outputDir: /path/to/trnasfer/input/
-  groupDir: /root/to/transfer
-  external_groupDir: /root/to/transfer/external/
-  logDir:
-  deepseq_qc: /path/to/deepseq/qc/
-  bioinfocoredir: /path/to/bionfo_qc
+  offloadDir: /path/to/ont/files (fast5 or pod5)
+  old_outputDir: /path/to/output/old_for_legacy
+  outputDir: /path/to/output/the_real_one             (aka as work dir)
+  groupDir: /rootpath/to/transfer/for/internal/groups (aka "periphery")
+  external_groupDir: /rootpath/to/transfer/for/external/groups
+  deepseq_qc: /path/to/deepseq/qc/ (SAMBA)
+  bioinfocoredir: /path/to/bionfo_qc (scp)
 
 ignore:
   flowcells:
     # flowcell IDs to ignore in the offload_path
     - 'PAK83895'
+    - ...
   dirs:
-    # full dirs to ignore in the offload_path
+    # flowcell paths to ignore
     - '20230512_1047_P2-7085206e51685c-A_PAK73534_a5e9ed5e'
-
-sambahost:
-  # user, host & private key file where the deepseq_qc is accessible (will access over ssh)
-  user: user
-  host: host
-  pkey: path/to/private_key
+    - ...
 
 parkour:
-  url: parkour/api/url
+  url: parkour/api/url/
   user: account
   password: password
+  pem: path/to/certificate
+
+
+basecaller: dorado # or guppy ()
+
+dorado_basecaller:
+  dorado_cmd: /path/to/dorado/basecaller
+  dorado_version: 
+  dorado_options: 
+  dorado_output: fastq # set to activate bam2fastq conversion (default for legacy)
+  dorado_model: # model name to overwrite inferred name
+  model_directory: /path/to/dorado/models
 
 guppy_basecaller:
   base_calling_cmd: path/to/guppy_basecaller
-  base_calling_options: --recursive --compress_fastq --device cuda:0 --num_callers 10 --chunk_size 500 --chunks_per_runner 768 --gpu_runners_per_device 8
-# guppy benchmark: https://esr-nz.github.io/gpu_basecalling_testing/gpu_benchmarking.html
-  base_calling_barcode_options: --trim_barcodes --num_barcode_threads 10
+  guppy_version: '6.5.7'
+  base_calling_options: --recursive --compress_fastq --chunk_size 2000 --chunks_per_runner 420 --do_read_splitting --trim_primers --trim_adapters --detect_mid_strand_adapter --detect_adapter
+# use with care: many guppy options are not functional or unsupported
+  base_calling_barcode_options: --enable_trim_barcodes
   base_calling_RNA_options: --reverse_sequence true --u_substitution true --trim_strategy rna
-  dna_model: /path/to/guppy/dna/model.cfg #hac
-  rna_model: /path/to/guppy/rna/model.cfg
-
-flowcell:
-  compatible_flowcells: FLO-MIN106
-  compatible_kits:  [SQK-PCS109,SQK-RNA002,SQK-RNA003,SQK-PCB109,SQK-LSK109,SQK-RAD004]
-  compatible_kits_with_barcoding: SQK-PCB109
+  models: /path/to/guppy/model.cfg 
 
 mapping:
   index_options: -t 5 -K 20M -x map-ont -d
   mapping_cmd: path/to/minimap2
-  mapping_dna_options: -t 2 -K 10M -ax map-ont -L
-  mapping_rna_options: -t 4 -K 10M -ax splice -L -u f
+  minimap2_version: '2.24-r1122'
+  mapping_dna_options: -t 40 -I100g -ax map-ont -L
+  mapping_rna_options: -t 40 -I100g -ax splice -L -u f
   samtools_cmd: /path/to/samtools
-  samtools_options: -@ 4
+  samtools_options: -@ 4 -m 200G -T /tmp
   bedtools_cmd: /path/to/bedtools
   bedtools_option: -s -split -name
 
 nanocomp:
-  qc_cmd: /path/to/NanoComp
+  qc_cmd: NanoComp
   qc_options: -t 20 --names
 
 pycoQc:
   barcodeSplit: /path/to/pycoqc/Barcode_split -u -v -f
-  pycoQc: "pycoQC"
+  pycoQc: pycoQC
   pycoQc_opts: ""
 
 genome:
   drosophila: /path/to/genome.fa
-  mouse: /path/to/genome.fa #mm10
-  hg38: /path/to/genome.fa
+  mouse: /path/to/genome.fa
+  human: /path/to/genome.fa
   lambdaPhage: /path/to/genome.fa
-  human_rRNA: /path/to/human_rRNA.fa
-  mouse_rRNA: /path/to/mouse_rRNA.fa
+  human_rRNA: /path/to/genome.fa
+  mouse_rRNA: /path/to/genome.fa
 
 transcripts:
-  drosophila: /path/to/genes.bed
-  mouse: /path/to/genes.bed #mm10
-  hg38: /path/to/genes.bed
+  drosophila:  /path/to/genes.bed
+  mouse: /path/to/genes.bed
+  human: /path/to/genes.bed
 
 contamination_report:
 human_genome: /path/to/genome.fa
-human_rRNA: /path/to/human_rRNA.fa
+human_rRNA: /path/to/genome.fa
 mouse_genome: /path/to/genome.fa
-mouse_rRNA: /path/to/mouse_rRNA.fa
+mouse_rRNA: /path/to/genome.fa
 
 email:
   from: a@host
-  to: c@host
-  host: mail.host
+  to: b@host
+  trigger: c@host
+  host: host

--- a/src/npr/communication.py
+++ b/src/npr/communication.py
@@ -79,7 +79,10 @@ def ship_qcreports(config, flowcell):
 
 
 def standard_text(config, QC):
-
+    """
+    Draft a short letter to end user that will be part of the success email
+    Include also QC metrics obtained from multiqc report
+    """
     samples = QC.pop('samples')
     frame = "\n-------\n"
     msg="Dear <...>\n" +\
@@ -96,6 +99,10 @@ def standard_text(config, QC):
 
 
 def send_email(subject, body, config, allreceivers=True):
+    """
+    Send email including key information about the run
+    Also print message to stdout
+    """
     mailer = MIMEMultipart('alternative')
     mailer['Subject'] = "[npr] [{}] {} {}".format(
         version('npr'),

--- a/src/npr/communication.py
+++ b/src/npr/communication.py
@@ -18,7 +18,7 @@ def ship_qcreports(config, flowcell):
     copy pycoQC reports and run report into samba drive
     copy both reports in bioinfo qc drive as well
     '''
-    return(0)
+
     # login info.
     _pkey = paramiko.RSAKey.from_private_key_file(
         config['sambahost']['pkey']

--- a/src/npr/communication.py
+++ b/src/npr/communication.py
@@ -109,7 +109,12 @@ def query_parkour(config, flowcell, msg):
     if flowcell == '20230331_1220_X4_FAV22714_872a401d':
         fc = 'FAV22714-2'
     else:
-        fc = flowcell.split("_")[3]
+        try:
+            fc = flowcell.split("_")[3]
+        except Exception as e:
+            print('Error: flowcell "{}" cannot be queried in parkour.'.format(flowcell))
+            print('Exception: {}'.format(e))
+            sys.exit(1)
     # test for flow cell re-use.
     # flowcell that's re-used gets higher increment.
     postfixes = ['-5', '-4', '-3', '-2', '-1']
@@ -152,16 +157,14 @@ def query_parkour(config, flowcell, msg):
             else:
                 print('protocol not found Default to dna.')
                 protocol = 'dna'
-                #sys.exit("protocol not found")
-            info_dict['protocol'] = protocol
+            config['info_dict']['protocol'] = protocol
             if organism not in config['genome'].keys():
                 organism = "other"
-            info_dict["organism"] = str(organism)
-            info_dict["protocol"] = protocol
+            config['info_dict']['organism'] = str(organism)
             msg += "nucleic acid  type = {}\n".format(protocol)
             msg += "organism = {}\n".format(organism)
-            return (info_dict, msg)
-    info_dict = {}
+            return (msg)
+
     msg += "Parkour query failed for {}.\n".format(fc)
     msg += "Parkour queries tried:\n"
     for fq in flowcellqueries:

--- a/src/npr/ont.py
+++ b/src/npr/ont.py
@@ -14,8 +14,9 @@ import signal
 from npr.ont_pipeline import find_new_flowcell
 from npr.ont_pipeline import read_flowcell_info
 from npr.ont_pipeline import read_samplesheet
-from npr.communication import query_parkour, send_email, ship_qcreports
-from npr.snakehelper import getfast5foot
+from npr.ont_pipeline import get_periphery
+from npr.communication import query_parkour, send_email, ship_qcreports, standard_text
+from npr.snakehelper import getfast5foot, get_seqdir, scan_multiqc
 import subprocess as sp
 from importlib.metadata import version
 from pathlib import Path
@@ -114,6 +115,9 @@ def ont(**kwargs):
     # start workflow.
     main(config)
 
+
+
+
 def main(config):
     while True:
         # Set HUP
@@ -131,15 +135,9 @@ def main(config):
                 # need parkour query only if 'organism' or 'protocol' is undefined
                 msg = query_parkour(config, flowcell, msg)
             # The following should be simplified but I did not want to touch
-            # read_flow_cell_info() for now
+            # read_flow_cell_info() for nowq
             config["info_dict"] = read_flowcell_info(config, config["info_dict"], base_path)
-            send_email(
-                "Flowcell {} found. Starting pipeline.\n".format(flowcell) + msg,
-                version('npr'),
-                os.path.basename(flowcell),
-                config,
-                allreceivers=False
-            )
+
             # read samplesheet
             bc_kit,data = read_samplesheet(config)
             config["data"] = data
@@ -163,6 +161,8 @@ def main(config):
             with open(configFile, 'w') as f:
                 yaml.dump(config, f, default_flow_style=False)
 
+            send_email("Found flowcell:", msg, config, allreceivers=False)
+
             """
             # This seems to be unused
             output_directory = config['info_dict']['flowcell_path']
@@ -176,10 +176,13 @@ def main(config):
                 fnames.sort(key=os.path.getctime)
                 n = int(fnames[-1].split("-")[-1].split(".")[0]) + 1  # get new run number
             """
+            config['info_dict']['transfer_path'] = get_periphery(config)
+
             print("[green]Starting snakemake. [/green]")
             print("file    {}".format(config['snakemake']['snakefile']))
             print("config  {}".format(config['info_dict']['configFile']))
             print("workdir {}".format(config['info_dict']['flowcell_path']))
+            print("transdir {}".format(config['info_dict']['transfer_path']))
 
             # static parameters are defined in dict config['snakemake']
             # flowcell specific parameters are taken from config['info_dict']
@@ -190,38 +193,22 @@ def main(config):
             )
             if not snak_stat:
                 msg += "snake crashed with {}".format(snak_stat)
-                print('[red] {} [/red]'.format(msg))
-                # send email here
-                sys.exit()
+                send_email("Snakemake failed for flowcell:", msg, config)
+                sys.exit(1)
 
-            msg = 'Project: {}\n'.format(config['data']['projects'][0])
             msg += 'pod5 compression: {}\n'.format(
                 getfast5foot(
                     config['info_dict']['base_path'],
                     config['info_dict']['flowcell_path']
                 )
             )
-            msg += 'organism: {}\n'.format(config['info_dict']['organism'])
-            msg += 'flowcell: {}\n'.format(config['info_dict']['flowcell'])
-            msg += 'kit: {}\n'.format(config['info_dict']['kit'])
-            msg += 'barcoding: {}\n'.format(config['info_dict']['barcoding'])
-            msg += 'barcoding kit: {}\n'.format(config['info_dict']['barcode_kit'])
-            msg += 'protocol: {}\n'.format(config['info_dict']['protocol'])
-            if config['basecaller']=="guppy":
-                msg += 'guppy version: {}\n'.format(config['guppy_basecaller']['guppy_version'])
-                msg += 'guppy model: {}\n'.format(config['info_dict']['model'].split('/')[-1])
-            if config['basecaller']=="dorado":
-                msg += 'dorado version: {}\n'.format(config['dorado_basecaller']['dorado_version'])
-                msg += 'dorado model: {}\n'.format(config["dorado_basecaller"]["dorado_model"])
-            msg += 'minimap2 version: {}\n\n'.format(config['mapping']['minimap2_version'])
-            msg += "flowcell {} is analysed successfully".format(flowcell)
             ship_qcreports(config, flowcell)
+            QC = scan_multiqc(config)
+            msg=standard_text(config, QC)
+            send_email("Successfully finished flowcell:", msg, config)
 
-            print(msg)
-            send_email(msg, version('npr'), os.path.basename(flowcell), config)
-            
             Path(os.path.join(config['info_dict']['flowcell_path'], 'analysis.done')).touch()
-            #print(config)
+
         else:
             print("No flowcells found. I go back to sleep.")
             sleep()

--- a/src/npr/ont_pipeline.py
+++ b/src/npr/ont_pipeline.py
@@ -111,13 +111,8 @@ def find_new_flowcell(config):
         # exit if sampleSheet.csv does not exists
         ss = os.path.join(flowcell, 'SampleSheet.csv')
         if not os.path.isfile(ss):
-            msg = "No SampleSheet.csv file.. Exiting.\n"
-            send_email(
-                msg,
-                version("npr"),
-                os.path.basename(flowcell),
-                config
-            )
+            msg = "No SampleSheet.csv file.\n"
+            send_email('Error for flowcell:', msg, config)
             sys.exit("no sampleSheet.")
         
         # return flowcell to ont()
@@ -304,3 +299,16 @@ def read_samplesheet(config):
         config["info_dict"]['barcode_kit']
     ))
     return config["info_dict"]['barcode_kit'], data
+
+def get_periphery(config):
+    """
+    Return the full pathname to the flowcell in the periphery
+    as it should be there after transfer
+    """
+    group    = config['data']['projects'][0].split("_")[-1].lower()
+    groupdir = os.path.join(config["paths"]["groupDir"],group)
+    # Warning: get_seqdir _creates_ directories as side effect
+    groupONT = get_seqdir(groupdir, "sequencing_data")
+    fc_base  = os.path.basename(config['info_dict']['flowcell_path'])
+    periphery = os.path.join(groupONT,fc_base)
+    return(periphery)

--- a/src/npr/rules/3_qc.smk
+++ b/src/npr/rules/3_qc.smk
@@ -56,14 +56,14 @@ rule qc_kraken:
         fastq="Project_{project}/Sample_{sample_id}/pass/{sample_name}.fastq.gz"
     output:
         report="FASTQC_Project_{project}/Sample_{sample_id}/{sample_name}_kraken.report",
-        output="FASTQC_Project_{project}/Sample_{sample_id}/{sample_name}_kraken.output",
     params:
         db=config['kraken']['db'],
         threads=config['kraken']['threads'],
+        output="-"  # "FASTQC_Project_{project}/Sample_{sample_id}/{sample_name}_kraken.output",
     log:
         stderr="log/kraken/project-{project}_id-{sample_id}_name-{sample_name}.log"
     shell:'''
-        kraken2 -db {params.db} --threads {params.threads} --use-names {input.fastq}  --output {output.output} --report {output.report} 2> {log.stderr}
+        kraken2 -db {params.db} --threads {params.threads} --use-names {input.fastq}  --output {params.output} --report {output.report} 2> {log.stderr}
     '''
 
 rule qc_multiqc: 


### PR DESCRIPTION
1. made parkour query optional if organism and protocol are specified as config['info_dict'] or through command line
This helps to run ont for individual flowcells that have no parkour record, or to test it without parkour access. 

2. Also added option for 'dryrun' to snakemake args - via config file or command line argument
In all cases, command line arguments will take precedence over config file

3. improved sending of emails and standardised reporting