### PR TITLE
Fix fastqc memory

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -90,6 +90,9 @@ pycoQc:
   pycoQc: pycoQC
   pycoQc_opts: ""
 
+fastqc:
+  memory: 10000
+
 multiqc:
   configfile: /path/to/multiqc/config/file
 

--- a/src/npr/rules_dorado/06_align.smk
+++ b/src/npr/rules_dorado/06_align.smk
@@ -5,6 +5,7 @@ Align reads usign dorado aligner (minimap2)
 source_bam = sample_dat + ".bam"
 source_seqsum = sample_dat + ".seqsum"
 target_bam  = sample_ana + ".align.bam"
+target_bai  = sample_ana + ".align.bam.bai"
 target_html = sample_qc + ".align_pycoqc.html"
 target_json = sample_qc + ".align_pycoqc.json"
 target_flagstat = sample_qc + ".align.flagstat"
@@ -21,6 +22,7 @@ rule align:
         seqsum = source_seqsum
     output:
         file = target_bam,
+        bai = target_bai,
 #        html = target_html,
 #        json = target_json,
         flagstat = target_flagstat

--- a/src/npr/rules_dorado/07_modbed.smk
+++ b/src/npr/rules_dorado/07_modbed.smk
@@ -32,6 +32,6 @@ rule bam2modbed:
     shell:'''
         # future: consider filtering zero modification or "nan" with "| awk '$11 != "nan" && $11>0.0'"
         #   remove or reduce stderr from processing
-        modbam2bed -t {threads} --combine {params.genome} {input.bam} | pigz -p {threads} > {output.bed} 2>> {log}
+        ( modbam2bed -t {threads} --combine {params.genome} {input.bam} | pigz -p {threads} > {output.bed} ) 2>> {log}
     '''
 

--- a/src/npr/rules_dorado/08_fastqc.smk
+++ b/src/npr/rules_dorado/08_fastqc.smk
@@ -21,12 +21,13 @@ rule fastqc:
     output: 
         target
     params:
-        odir = lambda wildcards: qc_dir.format(project=wildcards.project)
+        odir = lambda wildcards: qc_dir.format(project=wildcards.project),
+        memory = config['fastqc'].get('memory', 10000)
     threads: 4
     log:
         logpat
     benchmark:
         bchpat
     shell:''' 
-        fastqc --memory=4096 -t {threads} -o {params.odir} --dir {params.odir} --quiet {input} 2> {log}
+        fastqc --memory={params.memory} -t {threads} -o {params.odir} --dir {params.odir} --quiet {input} 2> {log}
     '''


### PR DESCRIPTION
- fastqc memory = 4096MB was insufficient. increased default and put into config
- fix old index problem. made bai explicit target in alignment rule
- reduced verbosity of modbam2bed and send stderr to log file 