### PR TITLE
updating conda env for pod5 (needs recent gcc)

### DIFF
--- a/src/npr/rules_dorado/envs/pod5.yaml
+++ b/src/npr/rules_dorado/envs/pod5.yaml
@@ -3,7 +3,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - cxx-compiler
+  - cython
   - python >= 3.10
   - pip
   - pip:
-    - pod5 == 0.3.10
+    - pod5 == 0.3.27


### PR DESCRIPTION
new pod5 files are incompatible with the old pod5 software, this updates the version