### PR TITLE
fix: counting skip pods to match the number in final_transfer

### DIFF
--- a/src/npr/ont_pipeline.py
+++ b/src/npr/ont_pipeline.py
@@ -92,11 +92,9 @@ def find_new_flowcell(config):
         # return flowcell to ont()
         msg = "SampleSheet.csv file found.\n"
         config["input"] = {"name": os.path.basename(flowcell)}
-        pod5_dir = os.path.join(flowcell, "pod5")
+        pod5_dir = os.path.join(flowcell, "pod5*")
         podCount = glob.glob(os.path.join(pod5_dir, "*.pod5"))
-        pod5_skip_dir = os.path.join(flowcell, "pod5_skip")
-        podCount_skip = glob.glob(os.path.join(pod5_skip_dir, "*.pod5"))
-        podCount_value = len(podCount) + len(podCount_skip)
+        podCount_value = len(podCount)
         pod5Summary_file = glob.glob(os.path.join(flowcell, "final_summary_*.txt"))[0]
         podSummary = pd.read_csv(pod5Summary_file, sep="=", header=None, names=["key", "value"])
         podSummary_value = int(podSummary.loc[podSummary["key"] == "pod5_files_in_final_dest", "value"].values[0])

--- a/src/npr/ont_pipeline.py
+++ b/src/npr/ont_pipeline.py
@@ -94,7 +94,9 @@ def find_new_flowcell(config):
         config["input"] = {"name": os.path.basename(flowcell)}
         pod5_dir = os.path.join(flowcell, "pod5")
         podCount = glob.glob(os.path.join(pod5_dir, "*.pod5"))
-        podCount_value = len(podCount)
+        pod5_skip_dir = os.path.join(flowcell, "pod5_skip")
+        podCount_skip = glob.glob(os.path.join(pod5_skip_dir, "*.pod5"))
+        podCount_value = len(podCount) + len(podCount_skip)
         pod5Summary_file = glob.glob(os.path.join(flowcell, "final_summary_*.txt"))[0]
         podSummary = pd.read_csv(pod5Summary_file, sep="=", header=None, names=["key", "value"])
         podSummary_value = int(podSummary.loc[podSummary["key"] == "pod5_files_in_final_dest", "value"].values[0])


### PR DESCRIPTION
## Description of Changes

The total number of pods reported in fina_transfer*.txt (pod5_files_in_final_dest=XX) also includes the pods in pod5_skip.

The fix will search for pod5 files in pod5/, pod5_skip/, pod5_fail/, pod5_pass/, etc.